### PR TITLE
fix(Promethus Config): Fix port label

### DIFF
--- a/monitoring/prometheus/01-prometheus-configmap.yaml
+++ b/monitoring/prometheus/01-prometheus-configmap.yaml
@@ -82,7 +82,7 @@ data:
           action: replace
           target_label: __metrics_path__
           regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_prometheus_io_port]
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
           action: replace
           target_label: __address__
           regex: (.+)(?::\d+);(\d+)


### PR DESCRIPTION
Hi there

Been doing a bit of a deep dive on prometheus deployments a while ago and your work formed a part of my research

Your example prom config was informative but there's a typo in the pod `__address__` definition. Should be `__meta_kubernetes_pod_annotation_prometheus_io_port` instead of `__meta_kubernetes_pod_prometheus_io_port`

Been trying to find out why my custom port definitions weren't being picked up and it appears the replace directive will be silently ignored if the label doesn't exist