### PR TITLE
missing serviceName in statefulset

### DIFF
--- a/monitoring/prometheus-ha/templates/prometheus.yaml
+++ b/monitoring/prometheus-ha/templates/prometheus.yaml
@@ -5,6 +5,7 @@ metadata:
   name: prometheus
   namespace: {{ .Values.namespace }}
 spec:
+  serviceName: {{ .Values.prometheus.clusterName }}
   replicas: {{ .Values.prometheus.replicas }}
   selector:
     matchLabels:

--- a/monitoring/prometheus-ha/templates/thanos-compacter.yaml
+++ b/monitoring/prometheus-ha/templates/thanos-compacter.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: thanos-compactor
 spec:
+  serviceName: thanos-compactor
   replicas: {{ .Values.thanos.compactor.replicas }}
   selector:
     matchLabels:


### PR DESCRIPTION
@Thakurvaibhav , This is great and thank you for connecting different K8s pieces together. Could you please review this?

```bash
$ helm install promthanos prometheus-ha/  --namespace monitoring --dry-run > prometheus-ha/helm_generated.yaml
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec
```