### PR TITLE
fix: use trivy official install script to fix CI scan failures

### DIFF
--- a/.github/workflows/chart-scan.yml
+++ b/.github/workflows/chart-scan.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Install Trivy
         if: matrix.step == 'trivy'
         run: |
-          VERSION=0.66.0
-          curl -sSL https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz \
-            | sudo tar -xz -C /usr/local/bin trivy
+          TRIVY_VERSION=0.69.3
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sudo sh -s -- -b /usr/local/bin v${TRIVY_VERSION}
           trivy --version
 
       - name: Install Checkov & xunit-viewer

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Install Trivy
         if: matrix.step == 'trivy'
         run: |
-          VERSION=0.66.0
-          curl -sSL https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz \
-            | sudo tar -xz -C /usr/local/bin trivy
+          TRIVY_VERSION=0.69.3
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sudo sh -s -- -b /usr/local/bin v${TRIVY_VERSION}
           trivy --version
 
       - name: Cache Trivy DB


### PR DESCRIPTION
## Problem

The `Install Trivy` step in both `daily-scan.yml` and `chart-scan.yml` workflows fails because Trivy v0.66.0 no longer has pre-built binary release assets on GitHub (`trivy_0.66.0_Linux-64bit.tar.gz` does not exist).

Failing run: https://github.com/Thakurvaibhav/k8s/actions/runs/23082447602/job/67053937541

## Fix

- Switch from direct tarball download to Trivy's [official install script](https://trivy.dev/docs/latest/getting-started/installation/#install-script-official), which is the recommended installation method and handles binary downloads correctly.
- Bump Trivy from v0.66.0 to v0.69.3 (latest stable).

## Changes

- `.github/workflows/daily-scan.yml` - Updated Trivy install step
- `.github/workflows/chart-scan.yml` - Updated Trivy install step